### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -5,7 +5,7 @@
     "author"      : "Andy Weidenbaum",
     "description" : "Double-entry accounting ledger parser",
     "depends"     : ["Digest::xxHash"],
-    "license"     : "http://unlicense.org/UNLICENSE",
+    "license"     : "Unlicense",
     "source-type" : "git",
     "source-url"  : "git://github.com/atweiden/txn-parser.git",
     "support"     : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license